### PR TITLE
Buffer time for about to expire should have been subtracted

### DIFF
--- a/client_hub_auth_lib/providers/vite/AuthProvider.tsx
+++ b/client_hub_auth_lib/providers/vite/AuthProvider.tsx
@@ -145,7 +145,7 @@ export function ClientHubAuthProvider({
   const aboutToExpire = (token: string, expirationBuffer = 10) => {
     const decoded = jwtDecode(token)
     if (decoded) {
-      return ((decoded.exp || 0) + expirationBuffer) * 1000 < Date.now()
+      return ((decoded.exp || 0) - expirationBuffer) * 1000 < Date.now()
     } else {
       return false
     }


### PR DESCRIPTION
# Problem

The about to expire logic on a Token adds a buffer rather than subtracts it causing tokens not to refresh in the few seconds right after they've expired rather than refreshing right before they expire.

# Solution

Change the about to expire check to subtract the buffer time instead.