### PR TITLE
Only do getUser in AuthProvider when we have an access token

### DIFF
--- a/client_hub_auth_lib/providers/vite/AuthProvider.tsx
+++ b/client_hub_auth_lib/providers/vite/AuthProvider.tsx
@@ -100,6 +100,9 @@ export function ClientHubAuthProvider({
 
   useEffect(() => {
     const getUser = async (): Promise<User | null> => {
+      if (accessToken === null) {
+        return null
+      }
       try {
         const response = await fetch(`${JWT_ISSUER}/api/user/`, {
           headers: {


### PR DESCRIPTION
# Problem

We try to get the current user data from the identity service regardless of whether the access token has been set or not. If the access token hasn't been set this results in a 401 status from the identity service

# Solution

Check that the access token is not null prior to attempting to get user data and skip doing that if it is.