### PR TITLE
chore: standardize AI agent commit attribution rules

### DIFF
--- a/agent-git-commit-policy.md
+++ b/agent-git-commit-policy.md
@@ -1,0 +1,19 @@
+## Git commits
+
+Every commit you create must include a `Co-Authored-By` trailer identifying the agent that produced it. This makes AI-assisted changes auditable and ensures correct attribution in code review tools.
+
+Format:
+- Write the commit subject and body normally.
+- Leave one blank line after the body.
+- Add a `Co-Authored-By` trailer on its own line, using the identity of the agent doing the work:
+
+      Co-Authored-By: <Agent Name> <agent-email@example.com>
+
+Use the identity that corresponds to you:
+- Claude Code / Claude → `Claude <noreply@anthropic.com>`
+- OpenAI Codex / ChatGPT → `Codex <noreply@openai.com>`
+- Cursor → `Cursor Agent <noreply@cursor.sh>`
+- GitHub Copilot → `Copilot <noreply@github.com>`
+- Any other agent → `<Product Name> <noreply@<vendor-domain>>`
+
+If you are operating on behalf of a specific human (pair-programming, executing a developer's task), keep that human as the commit author and add yourself via `Co-Authored-By`. Do not replace the human author.


### PR DESCRIPTION
Context & Rationale

As AI-assisted coding tools become more common across the organization, we are standardizing how these agents attribute their work. This PR introduces a new policy file to ensure that AI-assisted changes are properly auditable in code review tools, while maintaining the human developer as the primary author.

What's Included

Adds agent-git-commit-policy.md to the repository.

Establishes the requirement for a Co-Authored-By trailer in commits generated by AI agents (e.g., Claude, Cursor, Copilot).

Clarifies the exact formatting and email domains required for the trailer.

Impact

This is a documentation-only update being rolled out across repositories to establish a unified standard for AI commit tracking. No code logic is affected.